### PR TITLE
fix: lerna monorepo publish

### DIFF
--- a/deploy-build.sh
+++ b/deploy-build.sh
@@ -29,6 +29,8 @@ shopt -s nullglob globstar
 #### functions
 ###
 
+BUILDS_DIR="tmp/builds"
+
 function getLatestTag {
     ###
     # Find the most recent tag that is reachable from the current
@@ -83,7 +85,7 @@ function deployRepo {
 
     BUILD_REPO_NAME="${COMPONENT}"
     BUILD_DIR="${REPO_DIR}/build"
-    BUILD_REPO_DIR="tmp/${BUILD_REPO_NAME}"
+    BUILD_REPO_DIR="${BUILDS_DIR}/${BUILD_REPO_NAME}"
 
     BRANCH=${TRAVIS_BRANCH:-$(git symbolic-ref --short HEAD)}
     

--- a/publish-build.sh
+++ b/publish-build.sh
@@ -47,13 +47,13 @@ function exec () {
 
 function publishPackage () {
     local PACKAGE_DIR=$1
-    local PACKAGE_JSON="${PACKAGE_DIR}package.json"
+    local PACKAGE_JSON="${PACKAGE_DIR}/package.json"
 
     if [[ ! -e ${PACKAGE_JSON} ]]; then
         printerr "Package.json file '${PACKAGE_JSON}' does not exist, skipping publish."
     else
-        name=$(node -pe "require('${PACKAGE_DIR}package.json').name")
-        version=$(node -pe "require('${PACKAGE_DIR}package.json').version")
+        name=$(node -pe "require('${PACKAGE_JSON}').name")
+        version=$(node -pe "require('${PACKAGE_JSON}').version")
         echo "Publishing package: ${name} @ ${version}"
 
         exec "npm publish \"$PACKAGE_DIR\" --tag \"$DIST_TAG\" --access public"
@@ -69,16 +69,16 @@ echo "//registry.npmjs.org/:email=deployment@dhis2.org" >> ~/.npmrc
 
 if [ ! -d "./packages" ] && [ ! -d "${BUILDS_DIR}" ]; then
     dir=$(pwd)
-    publishPackage "${dir}/"
+    publishPackage "${dir}"
 elif [[ -d "${BUILDS_DIR}" ]]; then
     for dir in ${BUILDS_DIR}/*/
     do
-        publishPackage "${dir}"
+        publishPackage "${dir%/}"
     done
 else
     for dir in ./packages/*/
     do
-        publishPackage "${dir}"
+        publishPackage "${dir%/}"
     done
 fi
 

--- a/publish-build.sh
+++ b/publish-build.sh
@@ -5,8 +5,6 @@
 # - TRAVIS_TAG
 ###
 
-source ./shared.sh
-
 # start: shellharden
 if test "$BASH" = "" || "$BASH" -uc "a=();true \"\${a[@]}\"" 2>/dev/null; then
     # Bash 4.4, Zsh

--- a/publish-build.sh
+++ b/publish-build.sh
@@ -5,6 +5,8 @@
 # - TRAVIS_TAG
 ###
 
+source ./shared.sh
+
 # start: shellharden
 if test "$BASH" = "" || "$BASH" -uc "a=();true \"\${a[@]}\"" 2>/dev/null; then
     # Bash 4.4, Zsh
@@ -67,7 +69,7 @@ echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 echo "//registry.npmjs.org/:username=travis4dhis2" >> ~/.npmrc
 echo "//registry.npmjs.org/:email=deployment@dhis2.org" >> ~/.npmrc
 
-if [ ! -d "./packages" ] && [ ! -d "${BUILDS_DIR}" ]; then
+if [[ ! -d "./packages" ]] && [[ ! -d "${BUILDS_DIR}" ]]; then
     dir=$(pwd)
     publishPackage "${dir}"
 elif [[ -d "${BUILDS_DIR}" ]]; then


### PR DESCRIPTION
This PR:

* Fixes publish-build for non-[packages](https://github.com/dhis2/cli-packages) (or more specifically, non-[d2-ui](https://github.com/dhis2/d2-ui) Lerna mono-repos).  
* Moves the temporary build output directory (shared between `deploy` and `publish` scripts) to the more explicit `tmp/builds` and removes the duplicated prefixing from `publish-build`.
* Restructures the `publish-build` script to be a bit more readable and factored
* Implements a simple `--dry-run` option to `publish-build` and a tiny bit of fancy colored **stderr** output

Disclaimer: I have tested `publish-build`, but have not tested the `deploy-build` changes.