### PR TITLE
fix: don't allow args to be escaped, npm doesn't like quotes

### DIFF
--- a/publish-build.sh
+++ b/publish-build.sh
@@ -36,7 +36,7 @@ fi
 # based on api levels
 
 function exec () {
-    local CMD=$1
+    local CMD="$1"
 
     if [ $DRYRUN -eq 1 ]; then
         echo $CMD


### PR DESCRIPTION
This appears to fix the parameter quotation issue, which caused the following error when calling `npm publish`:

The reason this works is that the command itself is wrapped before being passed to the shell, so arguments are not expanded / quoted.

```sh
+exec 'npm publish "./tmp/builds/d2" --tag "latest" --access public'
+local 'CMD=npm publish "./tmp/builds/d2" --tag "latest" --access public'
+'[' 0 -eq 1 ']'
++npm publish '"./tmp/builds/d2"' --tag '"latest"' --access public
Unhandled rejection Error: ENOENT: no such file or directory, open '/home/travis/build/dhis2/d2/"./tmp/builds/d2"/package.json'
```