### PR TITLE
feat: use package name over filesystem structure

### DIFF
--- a/deploy-build.sh
+++ b/deploy-build.sh
@@ -198,16 +198,17 @@ function deployPackage {
     else
         for dir in packages/*/
         do
-            local COMPONENT=$(basename ${dir})
-            local PREFIX=${ROOT//-app/}
+            local COMPONENT=$(getPackageName ${dir})
+            COMPONENT=${COMPONENT//@dhis2\//}
+            COMPONENT=${COMPONENT//\"/}
 
             # justin case
             if [[ "$pkg_ver" == "null" ]]; then
-                pkg_ver=$(getVersion "./packages/${COMPONENT}")
+                pkg_ver=$(getVersion "$dir")
                 pkg_ver=${pkg_ver//\"/}
             fi
 
-            deployRepo "${PREFIX}-${COMPONENT}" "$dir"
+            deployRepo "${COMPONENT}" "$dir"
         done
     fi
 }


### PR DESCRIPTION
To avoid building out the d2-ci repo name from the file system, we grab
the package name from the package.json file instead.

Before the path `(d2-ui)/packages/(core)` was split where the
parenthesis are, and the package name `d2-ui-core` was built from those
tokens.

The package name in `package.json` is something like
`@dhis2/d2-ui-core`, so we can instead remove the @dhis2 to get a simple
reference to the name of the repo, instead of tying it to the file
system structure.