### PR TITLE
fix(monorepo): deploy the build directory

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5816,18 +5816,12 @@ async function deployRepo(opts) {
         core.debug(e.message)
     }
 
-    const artifact_build_dir = path.join(repo, build_dir)
+    const repo_build_dir = path.join(repo, build_dir)
 
-    if (shell.test('-d', artifact_build_dir)) {
-        core.info(`copy build artifacts: ${artifact_build_dir}`)
+    if (shell.test('-d', repo_build_dir)) {
+        core.info(`copy build artifacts: ${repo_build_dir}`)
 
-        const res_find_build = shell.ls(artifact_build_dir)
-
-        const res_cp_build = shell.cp(
-            '-r',
-            res_find_build,
-            artifact_repo_path
-        )
+        const res_cp_build = shell.cp('-r', repo_build_dir, artifact_repo_path)
         core.info(`cp build: ${res_cp_build.code}`)
 
         const res_cp_pkg = shell.cp(
@@ -5848,7 +5842,7 @@ async function deployRepo(opts) {
             )
 
         core.info(`find: ${res_find}`)
-        shell.cp('-r', res_find, artifact_repo_path)
+        shell.cp(res_find, artifact_repo_path)
     }
 
     shell

--- a/dist/index.js
+++ b/dist/index.js
@@ -5820,9 +5820,12 @@ async function deployRepo(opts) {
 
     if (shell.test('-d', artifact_build_dir)) {
         core.info(`copy build artifacts: ${artifact_build_dir}`)
+
+        const res_find_build = shell.ls(artifact_build_dir)
+
         const res_cp_build = shell.cp(
             '-r',
-            path.join(artifact_build_dir, '*'),
+            res_find_build,
             artifact_repo_path
         )
         core.info(`cp build: ${res_cp_build.code}`)
@@ -5831,6 +5834,7 @@ async function deployRepo(opts) {
             path.join(repo, 'package.json'),
             path.join(artifact_repo_path, 'package.json')
         )
+
         core.info(`cp pkg: ${res_cp_pkg.code}`)
     } else {
         core.info(`root package deployment: ${repo}`)
@@ -5844,7 +5848,7 @@ async function deployRepo(opts) {
             )
 
         core.info(`find: ${res_find}`)
-        res_find.map(f => shell.cp('-rf', f, artifact_repo_path))
+        shell.cp('-r', res_find, artifact_repo_path)
     }
 
     shell

--- a/dist/index.js
+++ b/dist/index.js
@@ -5565,6 +5565,8 @@ const http = __webpack_require__(369)
 const shell = __webpack_require__(739)
 const fg = __webpack_require__(406)
 
+shell.config.verbose = true
+
 // workaround to allow NCC to bundle these dynamically loaded modules
 __webpack_require__(833)
 __webpack_require__(272)
@@ -5815,6 +5817,7 @@ async function deployRepo(opts) {
     }
 
     const artifact_build_dir = path.join(repo, build_dir)
+
     if (shell.test('-d', artifact_build_dir)) {
         core.info(`copy build artifacts: ${artifact_build_dir}`)
         const res_cp_build = shell.cp(

--- a/index.js
+++ b/index.js
@@ -260,14 +260,12 @@ async function deployRepo(opts) {
         core.debug(e.message)
     }
 
-    const artifact_build_dir = path.join(repo, build_dir)
+    const repo_build_dir = path.join(repo, build_dir)
 
-    if (shell.test('-d', artifact_build_dir)) {
-        core.info(`copy build artifacts: ${artifact_build_dir}`)
+    if (shell.test('-d', repo_build_dir)) {
+        core.info(`copy build artifacts: ${repo_build_dir}`)
 
-        const res_find_build = shell.ls(artifact_build_dir)
-
-        const res_cp_build = shell.cp('-r', res_find_build, artifact_repo_path)
+        const res_cp_build = shell.cp('-r', repo_build_dir, artifact_repo_path)
         core.info(`cp build: ${res_cp_build.code}`)
 
         const res_cp_pkg = shell.cp(
@@ -288,7 +286,7 @@ async function deployRepo(opts) {
             )
 
         core.info(`find: ${res_find}`)
-        shell.cp('-r', res_find, artifact_repo_path)
+        shell.cp(res_find, artifact_repo_path)
     }
 
     shell

--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ async function main() {
 
 async function deployRepo(opts) {
     const { base, repo, gh_org, gh_usr, gh_token, build_dir, pkg } = opts
-    
+
     core.startGroup('Deploy repo options')
     core.info(`base: ${base}`)
     core.info(`repo: ${repo}`)

--- a/index.js
+++ b/index.js
@@ -264,17 +264,17 @@ async function deployRepo(opts) {
 
     if (shell.test('-d', artifact_build_dir)) {
         core.info(`copy build artifacts: ${artifact_build_dir}`)
-        const res_cp_build = shell.cp(
-            '-r',
-            path.join(artifact_build_dir, '*'),
-            artifact_repo_path
-        )
+
+        const res_find_build = shell.ls(artifact_build_dir)
+
+        const res_cp_build = shell.cp('-r', res_find_build, artifact_repo_path)
         core.info(`cp build: ${res_cp_build.code}`)
 
         const res_cp_pkg = shell.cp(
             path.join(repo, 'package.json'),
             path.join(artifact_repo_path, 'package.json')
         )
+
         core.info(`cp pkg: ${res_cp_pkg.code}`)
     } else {
         core.info(`root package deployment: ${repo}`)
@@ -288,7 +288,7 @@ async function deployRepo(opts) {
             )
 
         core.info(`find: ${res_find}`)
-        res_find.map(f => shell.cp('-rf', f, artifact_repo_path))
+        shell.cp('-r', res_find, artifact_repo_path)
     }
 
     shell

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ const http = require('isomorphic-git/http/node')
 const shell = require('shelljs')
 const fg = require('fast-glob')
 
+shell.config.verbose = true
+
 // workaround to allow NCC to bundle these dynamically loaded modules
 require('shelljs/src/cat')
 require('shelljs/src/rm')
@@ -259,6 +261,7 @@ async function deployRepo(opts) {
     }
 
     const artifact_build_dir = path.join(repo, build_dir)
+
     if (shell.test('-d', artifact_build_dir)) {
         core.info(`copy build artifacts: ${artifact_build_dir}`)
         const res_cp_build = shell.cp(

--- a/index.js
+++ b/index.js
@@ -42,7 +42,6 @@ async function main() {
 
     const opts = {
         build_dir,
-        cwd,
         gh_token,
         gh_org,
         gh_usr,
@@ -97,7 +96,6 @@ async function main() {
                     try {
                         await deployRepo({
                             ...opts,
-                            cwd: ws_cwd,
                             repo: ws_cwd,
                             base: path.basename(ws_cwd),
                             pkg: ws_pkg,
@@ -122,6 +120,12 @@ async function main() {
 
 async function deployRepo(opts) {
     const { base, repo, gh_org, gh_usr, gh_token, build_dir, pkg } = opts
+    
+    core.startGroup('Deploy repo options')
+    core.info(`base: ${base}`)
+    core.info(`repo: ${repo}`)
+    core.info(`build_dir: ${build_dir}`)
+    core.endGroup()
 
     const context = github.context
     const octokit = new github.GitHub(gh_token)
@@ -254,11 +258,12 @@ async function deployRepo(opts) {
         core.debug(e.message)
     }
 
-    if (shell.test('-d', build_dir)) {
-        core.info('copy build artifacts')
+    const artifact_build_dir = path.join(repo, build_dir)
+    if (shell.test('-d', artifact_build_dir)) {
+        core.info(`copy build artifacts: ${artifact_build_dir}`)
         const res_cp_build = shell.cp(
             '-r',
-            path.join(build_dir, '*'),
+            path.join(artifact_build_dir, '*'),
             artifact_repo_path
         )
         core.info(`cp build: ${res_cp_build.code}`)
@@ -269,7 +274,7 @@ async function deployRepo(opts) {
         )
         core.info(`cp pkg: ${res_cp_pkg.code}`)
     } else {
-        core.info('root package deployment')
+        core.info(`root package deployment: ${repo}`)
         const res_find = shell
             .ls(repo)
             .filter(


### PR DESCRIPTION
In a monorepo with build directories we need to ensure that we use the right path to the build dir under the virtual repo.