### PR TITLE
fix: monorepo and build deployments

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5816,7 +5816,7 @@ async function deployRepo(opts) {
 
     const repo_build_dir = path.join(repo, build_dir)
 
-    if (shell.test('-d', build_dir)) {
+    if (shell.test('-d', repo_build_dir)) {
         core.info('copy build artifacts')
         const res_cp_build = shell.cp(
             '-r',

--- a/dist/index.js
+++ b/dist/index.js
@@ -5595,9 +5595,6 @@ async function main() {
     const gh_org = core.getInput('github-org')
     const gh_usr = core.getInput('github-user')
 
-    const pkg_path = __webpack_require__.ab + "deploy-build/" + cwd + '/package.json'
-    const pkg = JSON.parse(shell.cat(pkg_path))
-
     const opts = {
         build_dir,
         cwd,
@@ -5612,6 +5609,9 @@ async function main() {
     core.info('Options for run:')
     core.info(`${JSON.stringify(opts, undefined, 2)}`)
     core.endGroup()
+
+    const pkg_path = __webpack_require__.ab + "deploy-build/" + cwd + '/package.json'
+    const pkg = JSON.parse(shell.cat(pkg_path))
 
     core.startGroup('Loaded package')
     core.info(`pkg ls: ${shell.ls(cwd)}`)

--- a/dist/index.js
+++ b/dist/index.js
@@ -5595,7 +5595,7 @@ async function main() {
     const gh_org = core.getInput('github-org')
     const gh_usr = core.getInput('github-user')
 
-    const pkg_path = path.join(cwd, 'package.json')
+    const pkg_path = __webpack_require__.ab + "deploy-build/" + cwd + '/package.json'
     const pkg = JSON.parse(shell.cat(pkg_path))
 
     const opts = {
@@ -5615,7 +5615,7 @@ async function main() {
 
     core.startGroup('Loaded package')
     core.info(`pkg ls: ${shell.ls(cwd)}`)
-    core.info(path.join(cwd, 'package.json'))
+    core.info(__webpack_require__.ab + "deploy-build/" + cwd + '/package.json')
     core.info(JSON.stringify(pkg, undefined, 2))
     core.endGroup()
 
@@ -5634,7 +5634,7 @@ async function main() {
             Promise.all(
                 ws.map(async w => {
                     core.info(`workspace: ${w}`)
-                    const ws_cwd = path.join(cwd, w)
+                    const ws_cwd = path.resolve(cwd, w)
 
                     const [wsPkg] = fg.sync(['package.json'], {
                         cwd: ws_cwd,
@@ -5667,7 +5667,7 @@ async function main() {
         } else {
             await deployRepo({
                 ...opts,
-                repo: cwd,
+                repo: path.resolve(cwd),
                 base: path.basename(cwd),
                 pkg,
             })
@@ -5744,7 +5744,7 @@ async function deployRepo(opts) {
     const artifact_repo_url = `https://github.com/${ghRoot}/${repo_name}.git`
     core.info(`artifact repo url: ${artifact_repo_url}`)
 
-    const artifact_repo_path = path.join('tmp', base)
+    const artifact_repo_path = path.resolve('tmp', base)
     core.info(`build repo path: ${artifact_repo_path}`)
 
     const res_rm = shell.rm('-rf', artifact_repo_path)
@@ -5811,7 +5811,7 @@ async function deployRepo(opts) {
         core.debug(e.message)
     }
 
-    const repo_build_dir = path.join(repo, build_dir)
+    const repo_build_dir = path.resolve(repo, build_dir)
 
     if (shell.test('-d', build_dir)) {
         core.info('copy build artifacts')
@@ -5844,7 +5844,7 @@ async function deployRepo(opts) {
 
     shell
         .echo(`${new Date()}\n${sha}\n${context.payload.head_commit.url}\n`)
-        .to(path.join(artifact_repo_path, 'BUILD_INFO'))
+        .to(path.resolve(artifact_repo_path, 'BUILD_INFO'))
 
     await git.add({
         ...config,

--- a/dist/index.js
+++ b/dist/index.js
@@ -5842,7 +5842,7 @@ async function deployRepo(opts) {
             )
 
         core.info(`find: ${res_find}`)
-        res_find.map(f => shell.cp('-r', f, artifact_repo_path))
+        res_find.map(f => shell.cp('-r', path.join(repo, f), artifact_repo_path))
     }
 
     shell

--- a/dist/index.js
+++ b/dist/index.js
@@ -5577,6 +5577,8 @@ __webpack_require__(661)
 __webpack_require__(380)
 __webpack_require__(580)
 
+shell.config.verbose = true
+
 try {
     const payload = JSON.stringify(github.context.payload, undefined, 2)
     core.debug(`The event payload: ${payload}`)
@@ -5653,7 +5655,6 @@ async function main() {
                     try {
                         await deployRepo({
                             ...opts,
-                            cwd: ws_cwd,
                             repo: ws_cwd,
                             base: path.basename(ws_cwd),
                             pkg: ws_pkg,
@@ -5810,18 +5811,20 @@ async function deployRepo(opts) {
         core.debug(e.message)
     }
 
+    const repo_build_dir = path.join(repo, build_dir)
+
     if (shell.test('-d', build_dir)) {
         core.info('copy build artifacts')
         const res_cp_build = shell.cp(
             '-r',
-            path.join(build_dir, '*'),
+            `${repo_build_dir}/*`,
             artifact_repo_path
         )
         core.info(`cp build: ${res_cp_build.code}`)
 
         const res_cp_pkg = shell.cp(
-            path.join(repo, 'package.json'),
-            path.join(artifact_repo_path, 'package.json')
+            `${repo}/package.json`,
+            `${artifact_repo_path}/package.json`
         )
         core.info(`cp pkg: ${res_cp_pkg.code}`)
     } else {
@@ -5836,7 +5839,7 @@ async function deployRepo(opts) {
             )
 
         core.info(`find: ${res_find}`)
-        res_find.map(f => shell.cp('-rf', f, artifact_repo_path))
+        res_find.map(f => shell.cp(f, artifact_repo_path))
     }
 
     shell

--- a/index.js
+++ b/index.js
@@ -260,7 +260,7 @@ async function deployRepo(opts) {
 
     const repo_build_dir = path.join(repo, build_dir)
 
-    if (shell.test('-d', build_dir)) {
+    if (shell.test('-d', repo_build_dir)) {
         core.info('copy build artifacts')
         const res_cp_build = shell.cp(
             '-r',

--- a/index.js
+++ b/index.js
@@ -39,9 +39,6 @@ async function main() {
     const gh_org = core.getInput('github-org')
     const gh_usr = core.getInput('github-user')
 
-    const pkg_path = path.resolve(cwd, 'package.json')
-    const pkg = JSON.parse(shell.cat(pkg_path))
-
     const opts = {
         build_dir,
         cwd,
@@ -56,6 +53,9 @@ async function main() {
     core.info('Options for run:')
     core.info(`${JSON.stringify(opts, undefined, 2)}`)
     core.endGroup()
+
+    const pkg_path = path.resolve(cwd, 'package.json')
+    const pkg = JSON.parse(shell.cat(pkg_path))
 
     core.startGroup('Loaded package')
     core.info(`pkg ls: ${shell.ls(cwd)}`)

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ async function main() {
     const gh_org = core.getInput('github-org')
     const gh_usr = core.getInput('github-user')
 
-    const pkg_path = path.join(cwd, 'package.json')
+    const pkg_path = path.resolve(cwd, 'package.json')
     const pkg = JSON.parse(shell.cat(pkg_path))
 
     const opts = {
@@ -59,7 +59,7 @@ async function main() {
 
     core.startGroup('Loaded package')
     core.info(`pkg ls: ${shell.ls(cwd)}`)
-    core.info(path.join(cwd, 'package.json'))
+    core.info(path.resolve(cwd, 'package.json'))
     core.info(JSON.stringify(pkg, undefined, 2))
     core.endGroup()
 
@@ -78,7 +78,7 @@ async function main() {
             Promise.all(
                 ws.map(async w => {
                     core.info(`workspace: ${w}`)
-                    const ws_cwd = path.join(cwd, w)
+                    const ws_cwd = path.resolve(cwd, w)
 
                     const [wsPkg] = fg.sync(['package.json'], {
                         cwd: ws_cwd,
@@ -111,7 +111,7 @@ async function main() {
         } else {
             await deployRepo({
                 ...opts,
-                repo: cwd,
+                repo: path.resolve(cwd),
                 base: path.basename(cwd),
                 pkg,
             })
@@ -188,7 +188,7 @@ async function deployRepo(opts) {
     const artifact_repo_url = `https://github.com/${ghRoot}/${repo_name}.git`
     core.info(`artifact repo url: ${artifact_repo_url}`)
 
-    const artifact_repo_path = path.join('tmp', base)
+    const artifact_repo_path = path.resolve('tmp', base)
     core.info(`build repo path: ${artifact_repo_path}`)
 
     const res_rm = shell.rm('-rf', artifact_repo_path)
@@ -255,7 +255,7 @@ async function deployRepo(opts) {
         core.debug(e.message)
     }
 
-    const repo_build_dir = path.join(repo, build_dir)
+    const repo_build_dir = path.resolve(repo, build_dir)
 
     if (shell.test('-d', build_dir)) {
         core.info('copy build artifacts')
@@ -288,7 +288,7 @@ async function deployRepo(opts) {
 
     shell
         .echo(`${new Date()}\n${sha}\n${context.payload.head_commit.url}\n`)
-        .to(path.join(artifact_repo_path, 'BUILD_INFO'))
+        .to(path.resolve(artifact_repo_path, 'BUILD_INFO'))
 
     await git.add({
         ...config,

--- a/index.js
+++ b/index.js
@@ -33,8 +33,13 @@ try {
 }
 
 async function main() {
+    core.startGroup('Runtime parameters:')
+    core.info(`CWD: ${process.cwd()}`)
+    core.info(`CWD ls: ${shell.ls(process.cwd())}`)
+    core.endGroup()
+
     const build_dir = core.getInput('build-dir')
-    const cwd = core.getInput('cwd')
+    const cwd = path.resolve(process.cwd(), core.getInput('cwd'))
     const gh_token = core.getInput('github-token')
     const gh_org = core.getInput('github-org')
     const gh_usr = core.getInput('github-user')
@@ -47,19 +52,16 @@ async function main() {
         gh_usr,
     }
 
-    core.startGroup('Runtime parameters:')
-    core.info(`CWD: ${process.cwd()}`)
-    core.info(`CWD ls: ${shell.ls(process.cwd())}`)
-    core.info('Options for run:')
+    core.startGroup('Options for run:')
     core.info(`${JSON.stringify(opts, undefined, 2)}`)
     core.endGroup()
 
-    const pkg_path = path.resolve(cwd, 'package.json')
+    const pkg_path = path.join(cwd, 'package.json')
     const pkg = JSON.parse(shell.cat(pkg_path))
 
     core.startGroup('Loaded package')
     core.info(`pkg ls: ${shell.ls(cwd)}`)
-    core.info(path.resolve(cwd, 'package.json'))
+    core.info(`pkg path: ${pkg_path}`)
     core.info(JSON.stringify(pkg, undefined, 2))
     core.endGroup()
 
@@ -78,21 +80,22 @@ async function main() {
             Promise.all(
                 ws.map(async w => {
                     core.info(`workspace: ${w}`)
-                    const ws_cwd = path.resolve(cwd, w)
+                    const ws_cwd = path.join(cwd, w)
+                    core.info(`ws cwd: ${ws_cwd}`)
 
-                    const [wsPkg] = fg.sync(['package.json'], {
+                    const [ws_pkg_path] = fg.sync(['package.json'], {
                         cwd: ws_cwd,
                         onlyFiles: true,
                         absolute: true,
                         dot: false,
                     })
 
-                    core.info(`ws pkg: ${wsPkg}`)
+                    core.info(`ws pkg path: ${ws_pkg_path}`)
 
-                    const ws_pkg = JSON.parse(shell.cat(wsPkg))
+                    const ws_pkg = JSON.parse(shell.cat(ws_pkg_path))
 
                     core.startGroup('Loaded WS package')
-                    core.info(`path: ${wsPkg}`)
+                    core.info(`path: ${ws_pkg_path}`)
                     core.info(JSON.stringify(ws_pkg, undefined, 2))
                     core.endGroup()
 
@@ -111,7 +114,7 @@ async function main() {
         } else {
             await deployRepo({
                 ...opts,
-                repo: path.resolve(cwd),
+                repo: cwd,
                 base: path.basename(cwd),
                 pkg,
             })
@@ -188,7 +191,7 @@ async function deployRepo(opts) {
     const artifact_repo_url = `https://github.com/${ghRoot}/${repo_name}.git`
     core.info(`artifact repo url: ${artifact_repo_url}`)
 
-    const artifact_repo_path = path.resolve('tmp', base)
+    const artifact_repo_path = path.resolve(process.cwd(), 'tmp', base)
     core.info(`build repo path: ${artifact_repo_path}`)
 
     const res_rm = shell.rm('-rf', artifact_repo_path)
@@ -255,7 +258,7 @@ async function deployRepo(opts) {
         core.debug(e.message)
     }
 
-    const repo_build_dir = path.resolve(repo, build_dir)
+    const repo_build_dir = path.join(repo, build_dir)
 
     if (shell.test('-d', build_dir)) {
         core.info('copy build artifacts')
@@ -283,12 +286,12 @@ async function deployRepo(opts) {
             )
 
         core.info(`find: ${res_find}`)
-        res_find.map(f => shell.cp(f, artifact_repo_path))
+        res_find.map(f => shell.cp('-r', f, artifact_repo_path))
     }
 
     shell
         .echo(`${new Date()}\n${sha}\n${context.payload.head_commit.url}\n`)
-        .to(path.resolve(artifact_repo_path, 'BUILD_INFO'))
+        .to(path.join(artifact_repo_path, 'BUILD_INFO'))
 
     await git.add({
         ...config,

--- a/index.js
+++ b/index.js
@@ -286,7 +286,9 @@ async function deployRepo(opts) {
             )
 
         core.info(`find: ${res_find}`)
-        res_find.map(f => shell.cp('-r', f, artifact_repo_path))
+        res_find.map(f =>
+            shell.cp('-r', path.join(repo, f), artifact_repo_path)
+        )
     }
 
     shell


### PR DESCRIPTION
Can be verified by looking at the deployed result from the status checks in this repo, e.g.

- Single package **without** build step: https://github.com/d2-ci/deploy-build-test-repo/tree/fix-deploys
- Single package **with** build step: https://github.com/d2-ci/deploy-build-test-repo-build/tree/fix-deploys
- Multiple packages **without** build step:
  - https://github.com/d2-ci/deploy-build-test-monorepo-a/tree/fix-deploys
  - https://github.com/d2-ci/deploy-build-test-monorepo-b/tree/fix-deploys
- Multiple packages **with** build step:
  - https://github.com/d2-ci/deploy-build-test-monorepo-a/tree/fix-deploys
  - https://github.com/d2-ci/deploy-build-test-monorepo-b/tree/fix-deploys

The sources example packages can be found here: https://github.com/dhis2/deploy-build/tree/master/examples

The workflow for testing is here: https://github.com/dhis2/deploy-build/blob/master/.github/workflows/deploy-build.yml

Would be nice to have automatic verification on the deployed results to d2-ci as a status check, but not implemented yet.