### PR TITLE
fix: remove old build artifacts before copying in new ones

### DIFF
--- a/deploy-build.sh
+++ b/deploy-build.sh
@@ -95,8 +95,8 @@ function deployRepo {
 
     if [[ -d "$BUILD_DIR" ]]; then
         echo "Copy the build artifacts from ${BUILD_DIR}"
-        rm -rf $BUILD_REPO_DIR/*
-        cp -r $BUILD_DIR/* $BUILD_REPO_DIR/
+        rm -rf $BUILD_REPO_DIR
+        cp -r $BUILD_DIR $BUILD_REPO_DIR
 
         echo "Copy package.json to ${BUILD_REPO_DIR}"
         cp "${REPO_DIR}/package.json" "${BUILD_REPO_DIR}/package.json"

--- a/index.js
+++ b/index.js
@@ -262,9 +262,13 @@ async function deployRepo(opts) {
 
     if (shell.test('-d', repo_build_dir)) {
         core.info('copy build artifacts')
+        
+        const res_rm = shell.rm('-rf', artifact_repo_path)
+        core.info(`rm: ${res_rm.code}`)
+        
         const res_cp_build = shell.cp(
             '-r',
-            `${repo_build_dir}/*`,
+            repo_build_dir,
             artifact_repo_path
         )
         core.info(`cp build: ${res_cp_build.code}`)

--- a/index.js
+++ b/index.js
@@ -263,8 +263,8 @@ async function deployRepo(opts) {
     if (shell.test('-d', repo_build_dir)) {
         core.info('copy build artifacts')
         
-        const res_rm = shell.rm('-rf', artifact_repo_path)
-        core.info(`rm: ${res_rm.code}`)
+        const res_rm_build = shell.rm('-rf', artifact_repo_path)
+        core.info(`rm: ${res_rm_build.code}`)
         
         const res_cp_build = shell.cp(
             '-r',


### PR DESCRIPTION
This was causing huge amounts of build bloat, as the old files were not being cleaned up before force-pushing the new build.  Since source files are usually hashed and large, this caused the DV build to bloat to more than 500mb